### PR TITLE
Not pushing settings for not passed styles

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -517,7 +517,7 @@ export default class Delimiter {
                 ),
             );
         }
-        if (this.availableDelimiterStyles.includes('line')) {
+         if (this.availableDelimiterStyles.includes('line') && this.availableLineWidths.length > 1) {
             const lineWidths = this.availableLineWidths.map((width) =>
                 this._createSetting(
                     getLineWidthIcon(width),
@@ -530,7 +530,7 @@ export default class Delimiter {
             );
             settings.push(...lineWidths);
 
-            if (this.currentDelimiterStyle === 'line') {
+            if (this.currentDelimiterStyle === 'line' && this.availableLineThickness.length > 1) {
                 const lineThickness = this.availableLineThickness.map(
                     (thickness) =>
                         this._createSetting(

--- a/src/index.js
+++ b/src/index.js
@@ -494,27 +494,56 @@ export default class Delimiter {
    * @returns {[{*}]}
    */
   renderSettings() {
-    const starStyle = this._createSetting(
-      asteriskIcon, 'Star', () => this._setStar(), this.currentDelimiterStyle === 'star', 'star'
-    );
-    const dashStyle = this._createSetting(
-      delimiterIcon, 'Dash', () => this._setDash(), this.currentDelimiterStyle === 'dash', 'dash'
-    );
-    const lineWidths = this.availableLineWidths.map(width => 
-      this._createSetting(
-        getLineWidthIcon(width), this._getFormattedLabel(width, 'Line ', '%'), () => this._setLine(width), 
-        this.currentDelimiterStyle === 'line' && width === this.currentLineWidth, 'line'
-      )
-    );
-    let lineThickness = [];
-    if (this.currentDelimiterStyle === 'line') {
-      lineThickness = this.availableLineThickness.map(thickness => 
-        this._createSetting(
-          getThicknessIcon(thickness), this._getFormattedLabel(thickness, 'Thickness '), 
-          () => this._setLineThickness(thickness), thickness === this.currentLineThickness, 'thickness')
-      );
-    }
+        const settings = [];
+        if (this.availableDelimiterStyles.includes('star')) {
+            settings.push(
+                this._createSetting(
+                    asteriskIcon,
+                    'Star',
+                    () => this._setStar(),
+                    this.currentDelimiterStyle === 'star',
+                    'star',
+                ),
+            );
+        }
+        if (this.availableDelimiterStyles.includes('dash')) {
+            settings.push(
+                this._createSetting(
+                    delimiterIcon,
+                    'Dash',
+                    () => this._setDash(),
+                    this.currentDelimiterStyle === 'dash',
+                    'dash',
+                ),
+            );
+        }
+        if (this.availableDelimiterStyles.includes('line')) {
+            const lineWidths = this.availableLineWidths.map((width) =>
+                this._createSetting(
+                    getLineWidthIcon(width),
+                    this._getFormattedLabel(width, 'Line ', '%'),
+                    () => this._setLine(width),
+                    this.currentDelimiterStyle === 'line' &&
+                        width === this.currentLineWidth,
+                    'line',
+                ),
+            );
+            settings.push(...lineWidths);
 
-    return [starStyle, dashStyle, ...lineWidths, ...lineThickness];
-  }
+            if (this.currentDelimiterStyle === 'line') {
+                const lineThickness = this.availableLineThickness.map(
+                    (thickness) =>
+                        this._createSetting(
+                            getThicknessIcon(thickness),
+                            this._getFormattedLabel(thickness, 'Thickness '),
+                            () => this._setLineThickness(thickness),
+                            thickness === this.currentLineThickness,
+                            'thickness',
+                        ),
+                );
+                settings.push(...lineThickness);
+            }
+        }
+        return settings;
+    }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -517,18 +517,20 @@ export default class Delimiter {
                 ),
             );
         }
-         if (this.availableDelimiterStyles.includes('line') && this.availableLineWidths.length > 1) {
-            const lineWidths = this.availableLineWidths.map((width) =>
-                this._createSetting(
-                    getLineWidthIcon(width),
-                    this._getFormattedLabel(width, 'Line ', '%'),
-                    () => this._setLine(width),
-                    this.currentDelimiterStyle === 'line' &&
+        if (this.availableDelimiterStyles.includes('line')) {
+            if(this.availableLineWidths.length > 1) {
+                const lineWidths = this.availableLineWidths.map((width) =>
+                    this._createSetting(
+                        getLineWidthIcon(width),
+                        this._getFormattedLabel(width, 'Line ', '%'),
+                        () => this._setLine(width),
+                        this.currentDelimiterStyle === 'line' &&
                         width === this.currentLineWidth,
-                    'line',
-                ),
-            );
-            settings.push(...lineWidths);
+                        'line',
+                    ),
+                );
+                settings.push(...lineWidths);
+            }
 
             if (this.currentDelimiterStyle === 'line' && this.availableLineThickness.length > 1) {
                 const lineThickness = this.availableLineThickness.map(


### PR DESCRIPTION
I noticed that the styles you didn't push in the Editor instance > tools > delimiter > config > styleOptions where still displayed even though clicking on them did nothing.

I think that is not an expected behaviour?