### PR TITLE
Fix: center delimiter hr element

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,7 @@
 	font-weight: 900;
 }
 .ce-delimiter-line hr {
+	display: inline-block;
 	font-size: 48px;
 	border-style: solid;
 	border-color: black;


### PR DESCRIPTION
When using editorjs-delimiter with Bootstrap 5 the hr elements do not center properly.  This fixes the issue.